### PR TITLE
Fix to make source of error easier to locate

### DIFF
--- a/message_box.py
+++ b/message_box.py
@@ -72,7 +72,7 @@ class MyEntryWindow(Dialog):
         self.wm_title("CRUK Generator Data Entry")
         master.grid()
         self.label1 = ttk.Label(master, text="Enter sample status: options are s (sequenced), f (failed) or w "
-                                             "withdrawn)")
+                                             "(withdrawn)")
         self.label1.grid(column=0, row=0)
         self.e1 = ttk.Entry(master)
         self.e1.grid(column=1, row=0, pady=10)

--- a/parse_report.py
+++ b/parse_report.py
@@ -114,6 +114,9 @@ def get_test_status(gene_data):
         test_status = test_status_dict.get("Success")
     if gene_status == "Failure":
         test_status = test_status_dict.get("Complete Fail")
+    else:
+        raise Exception(f"Invalid status for gene. Options are Success or Failure. Status for "
+                        f"gene {gene_data.get('GENE')} is {gene_status}")
     return test_status
 
 

--- a/report_cruk.py
+++ b/report_cruk.py
@@ -233,6 +233,9 @@ class ReportCruk:
         :return: string for logging indicating that all required data for the xml file is present in the input
         dictionary
         '''
+        # Dump data to log file to help with troubleshooting (if needed)
+        self.log.debug(f"Write out of dictionary of information: {self.info_dict}")
+
         # Sample level
         for k, v in self.info_dict.items():
             try:

--- a/tests/XML_reporting/BARTS/20191121 YY479-9-n-AH.xml
+++ b/tests/XML_reporting/BARTS/20191121 YY479-9-n-AH.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <smpSample xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" smVersion="3.8">
-  <smClinicalHub name="13 - Leicester">
+  <smClinicalHub name="9 - Barts &amp; Brighton">
     <patient>
-      <organisationCode>YY476</organisationCode>
-      <localPatientIdentifier>6</localPatientIdentifier>
+      <organisationCode>YY479</organisationCode>
+      <localPatientIdentifier>9</localPatientIdentifier>
     </patient>
   </smClinicalHub>
   <sample>
     <clinicalHubElements>
-      <sourceSampleIdentifier>AF</sourceSampleIdentifier>
+      <sourceSampleIdentifier>AH</sourceSampleIdentifier>
       <typeOfSample>8</typeOfSample>
       <morphologySnomed><![CDATA[N/A]]></morphologySnomed>
       <tumourType>3</tumourType>
@@ -16,12 +16,12 @@
     </clinicalHubElements>
     <technologyHubElements>
       <dateSampleReceived>2019-10-26</dateSampleReceived>
-      <labSampleIdentifier>19M6</labSampleIdentifier>
+      <labSampleIdentifier>19M8</labSampleIdentifier>
       <reportReleaseDate>2019-11-21</reportReleaseDate>
       <volumeBankedNucleicAcid><![CDATA[0]]></volumeBankedNucleicAcid>
       <concentrationBankedNucleicAcid><![CDATA[9.73]]></concentrationBankedNucleicAcid>
       <bankedNucleicAcidLocation><![CDATA[Rm2.14 DNA bank_4oC]]></bankedNucleicAcidLocation>
-      <bankedNucleicAcidIdentifier><![CDATA[19M6]]></bankedNucleicAcidIdentifier>
+      <bankedNucleicAcidIdentifier><![CDATA[19M8]]></bankedNucleicAcidIdentifier>
     </technologyHubElements>
   </sample>
   <smTechnologyHub name="2 - Cardiff">
@@ -91,8 +91,8 @@
         <methodOfTest><![CDATA[19]]></methodOfTest>
         <scopeOfTest><![CDATA[ENST00000262643:Exons2-11]]></scopeOfTest>
         <dateTestResultsReleased>2019-11-21</dateTestResultsReleased>
-        <testResult><![CDATA[c.5435, c.430923, c.54353 A>C]]></testResult>
-        <testReport><![CDATA[Tier 5 variants everywhere]]></testReport>
+        <testResult><![CDATA[No variant detected]]></testResult>
+        <testReport><![CDATA[High confidence]]></testReport>
         <testStatus>1</testStatus>
         <comments><![CDATA[These results are intended for research purposes.]]></comments>
       </test>
@@ -434,7 +434,7 @@
         <testResult><![CDATA[No variant detected]]></testResult>
         <testReport><![CDATA[High confidence]]></testReport>
         <testStatus>1</testStatus>
-        <comments><![CDATA[These results are intended for research purposes. additional comment test.]]></comments>
+        <comments><![CDATA[These results are intended for research purposes.]]></comments>
       </test>
       <test>
         <gene>56</gene>

--- a/tests/XML_reporting/Manchester/20191121 YY476-7-n-AG.xml
+++ b/tests/XML_reporting/Manchester/20191121 YY476-7-n-AG.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <smpSample xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" smVersion="3.8">
-  <smClinicalHub name="13 - Leicester">
+  <smClinicalHub name="7 - Manchester">
     <patient>
       <organisationCode>YY476</organisationCode>
-      <localPatientIdentifier>6</localPatientIdentifier>
+      <localPatientIdentifier>7</localPatientIdentifier>
     </patient>
   </smClinicalHub>
   <sample>
     <clinicalHubElements>
-      <sourceSampleIdentifier>AF</sourceSampleIdentifier>
+      <sourceSampleIdentifier>AG</sourceSampleIdentifier>
       <typeOfSample>8</typeOfSample>
       <morphologySnomed><![CDATA[N/A]]></morphologySnomed>
       <tumourType>3</tumourType>
@@ -16,12 +16,12 @@
     </clinicalHubElements>
     <technologyHubElements>
       <dateSampleReceived>2019-10-26</dateSampleReceived>
-      <labSampleIdentifier>19M6</labSampleIdentifier>
+      <labSampleIdentifier>19M7</labSampleIdentifier>
       <reportReleaseDate>2019-11-21</reportReleaseDate>
       <volumeBankedNucleicAcid><![CDATA[0]]></volumeBankedNucleicAcid>
       <concentrationBankedNucleicAcid><![CDATA[9.73]]></concentrationBankedNucleicAcid>
       <bankedNucleicAcidLocation><![CDATA[Rm2.14 DNA bank_4oC]]></bankedNucleicAcidLocation>
-      <bankedNucleicAcidIdentifier><![CDATA[19M6]]></bankedNucleicAcidIdentifier>
+      <bankedNucleicAcidIdentifier><![CDATA[19M7]]></bankedNucleicAcidIdentifier>
     </technologyHubElements>
   </sample>
   <smTechnologyHub name="2 - Cardiff">
@@ -91,8 +91,8 @@
         <methodOfTest><![CDATA[19]]></methodOfTest>
         <scopeOfTest><![CDATA[ENST00000262643:Exons2-11]]></scopeOfTest>
         <dateTestResultsReleased>2019-11-21</dateTestResultsReleased>
-        <testResult><![CDATA[c.5435, c.430923, c.54353 A>C]]></testResult>
-        <testReport><![CDATA[Tier 5 variants everywhere]]></testReport>
+        <testResult><![CDATA[No variant detected]]></testResult>
+        <testReport><![CDATA[High confidence]]></testReport>
         <testStatus>1</testStatus>
         <comments><![CDATA[These results are intended for research purposes.]]></comments>
       </test>
@@ -434,7 +434,7 @@
         <testResult><![CDATA[No variant detected]]></testResult>
         <testReport><![CDATA[High confidence]]></testReport>
         <testStatus>1</testStatus>
-        <comments><![CDATA[These results are intended for research purposes. additional comment test.]]></comments>
+        <comments><![CDATA[These results are intended for research purposes.]]></comments>
       </test>
       <test>
         <gene>56</gene>

--- a/tests/pdfs/20191121 YY476-6-n-AF.pdf
+++ b/tests/pdfs/20191121 YY476-6-n-AF.pdf
@@ -1,0 +1,106 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20191121172855+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20191121172855+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 3 /Kids [ 3 0 R 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2207
+>>
+stream
+GauaC=``=U'SYHC/+CuT1h3cj#]=qON;',k4Kcqq4>INh/#1(KjJ;bK"gifULD2C:BKMYbL+[`]QB0B=$!K$#?=NkS3+_G9B7HEZ-7$e'R8AHDq%Z!7&,n::Z/%=#/;fTUAg0)/QiLIu(>fVGhSKR;M<RKgYJm<&H?V+^cc3k3_EL/3rP4B/J6hF0:bPmrnN4q/Zi%N0qqJbUa&'`@(A%;;I(t&+8N_e6Zbb%7X&#7C5cHU="eVjT/,OF'>*aSsTD;HW'&t-(+Hn51k:oMu8Sh,L[E#2ejCpZH($teVNobJq83"41ApV<naQB?L$#a[T2<Lb*Z]Id8(]*N2U$q0&BsCk+d7pko]_^To=D>2pVN2D^VIuq?9QH7)"<Y^P[Jd/o[*V0'rh2j4*G_dW=$4TngQVkM_Kj:e`5\RrD@i0VaC;uW^RLP6b[-0"6UDUqQ,RPNRMK[^s8F-3AYLBTos=D[?=?af9;L=U9Xh6HRn,DRe"n&(h9+ki5ah4=AXPHbX$^%0N@h7_X2]=*.Ef_ses/[6]/l0FeieU/5t4[=h'4=7A-@VQ*^RW)&PQ3R5u867BI7gi@o$':TBF\JqA[T%ioX@%2RBEIXj'sk0&93(Bk>;qcniA)@,B/"VQEdqiW0jXZ09$$R-I_E1tp5\*BpLFk&*/.eFq'nA\M>P/VI"fRO+LfenC0bAMZ6fVb+Kd.'q/XrdquHI*li)9J>qWhusQZ?Kmu(b>kfn>.-I\+q&Y41T2`MoBFbP$b!+**f?,/WBdhS9e*Fm,#AX1*aRo[^a5Y$p@!C;ADpolbtBGcrTcK@;(T`+CrJkiV2$CA+i"C$I2m``@)Mg,IQZ&b@J`o,!fDpiJOVm_J'^j%4`m$l0_=UT[aMLE*\ilKfmk[j_[#o1[!8)ooeP0TD4#VG.g!,/m*X?0!Eqa5"0EE]MuYH&O$O-jq*POW:nRu&H\GLX*h-.r$cjCHmPuFBW<JO<e-_C)&YK<g0k^S4IqX0Lh%EmV[T@/<hWkcuc$FgNU5<&=pZ1E3P`d0idT^N:q#R.K;%"6:;i;&;JQb=I:MOGZH2EBa;jO0odC%KHDJBbt3jjc)6nMm/9eBg@TGE[WQ.jkTWt*mj_ie1gf2<P#W!/t[W!1[*C&oQ/C&ntT[=E(se10B]XSlHk8M-TNW')A9#`/,A=ud/]ng1_pr%Nq+(`fnjTL,6ld/IWA$/*^u-Nnr#bC$B--F,d<Q;%>*MuS5ikQQZO^lQ>fdYp@m%Y5lh+g;C=St',q?a;(W#*cSF\(A5;),S@#@)0j5!_,YG!%f>J/%#1l))jL4P3`7]#23j<7)0SbhW>:7=\4H%TT3Fg)#7["N%Y395djI)70Y%-m=Xl37<Hj.c>U=gKp4OC9#C6T6lr'<1%M1W)W#@H&_UKi:&M>78YHpH4hEj@-<s](UpnthEWecO_\Ors`tgA&?jk'LMJ_FH=A-NU#=S=A9XYXO!U8E3)J->\j=tHO,CaM1'+20uCp2J@s3t5\ZW1HBkZVd/=2YYa+)Ct'$sUNg+'ZO6Jh8,"/%3kj[13M0&J3cZ[mtWFC'!EJ[=mkULcP_ldQua:![\Up!SLeQjZp[X=B'q:?IGJMPWbZCe1kV;,CaBhd3V$caS#pW$Cm(f<[RmQT?m(G@KG::Y^;OQ7kC;C!=S[Io*T^RE!95<U_Quh\`XCVd>G#-4X]#3gTN,j^$EEC7<[lq3D4fLc(n"RDdR;Qm;"8eI@7LPDnYcY370#,m6qepP*,rijXhoOGdV+lYHdBdAJX+9nI8e('1#'sIXnM)c#56a9,$e@\!6d#rouG+@]1C2PL7*7A]ssZ0;;ga($:!P9t:r2[POqm466J_s+0re)4hCWh80s8-n4LuXf[#*l1@DVdl.=#0D#5@f(A[q+HR34\UJ.RZYB6^,\Id6kFP;K"DlJ>,#o#=U'lZp/S'_k,gol;'O?OH.Ue7IOF;qp'!aqBMJLbH72Jk0C=o6ga]^Q<d=juj)Rd-`fdD.t+^9&^UfIq/FJ5X6%9mqJYZ;3;F<OefL+TtJY?-@CeOXJ`8BXWT#HKmdoqAD8X^8D@bsJh/Q>H5!6+K%d-g#:$(!=%#j(<bEEE=RKTl^i@b<d)U:[5-E8fMu.1*29kF+DrR/#Z&^WI";=6ZsPXq4r%!2!eW]WnLn)m:!UW-;k%^BUF^p+H9:`cEV,6kMW64VTm-PHWL)g@gE#9kGn>^~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2154
+>>
+stream
+GauaC?ZXp\'ZJu$.J29[$slMkr21'r!Ko:mUfj!;S`q@"-_Z_h(W^bar^mZdm4?7YVbT9HgJKVoF(P;tO_eIB\9Wr/n(ApqK*hGR<%oKKjH^)e-oSVH-^1=?btIE[)b[&N*6;*4jte@"o>(4jaF%/N5pPpp/B2`cBr0Yq*u<&=D#1rmSo-_GUX3M;fj^7a[b:L92Yk?>n#bJSk#FHs.LOU[7mGu0orEtF?IW3QqPT<:;'H(<P2n!</uLYpr7LWmr>`N?WB/"4&B:4fk/1UM@i\^M+H`qWK"_*63%rOSP`/:j@3AMfZ(=M=3b,YfNMLt;mkKuPhUA2=VS#nh1rBeOCXoR-md4)FZImp\\h`0tY81];m-SL]=[mc8eY]G%7o2fg"JocR6'3?9.,sq4'H.iT&[manON7\7hEHMt14W60T-<+8*-<V&*f4XfH!+hORdB;T;aMJ(<P#,/EMZXJXA>[aiW0iVer]63EcT^/SEO876^1CG>qJ"0QStiOV1KtPZ,?*C\e],WnPf%gOA)9:#Z73FZ8E#X4ZMf#l$>'iDOV0O3D*Nq3Y3O`.'#cTn<g+UrqG(m1L+gh*k!"G21R<FgMAmrk3R9![Xi8+T&$aA:[@JM9st@s^LYU@c+u'a^&B0nV\RT"&"4#rK,#!T_(+Jg=qUS2<IkaOBA772c0"EO,"?4']6cG?/T2HsCcT\mTg_W\cm#cd6>HSmL:4X"-+&3jpgc^A((`*kD*HWFBE<Ae>/83$>/5dm/KidsZo[o9<YD&/FN8l;;bAX7]VAM]"DRs_N*=$<T3B$`67j>7.CEUL:TYg;$g:nm/d)>^5ajm-7FX&,!@*)/!>>gJJ8D.59)i%:W!UrT\s)G'"^4/OLGnKj9!&9X0kp_6Iqeut$FRt=G"F7jema:_#DfOV[X%:<;@=o9eB4@tQ7o3@j=tBM,CaG/'+2.gk]TM!9`4)(3bbK-dI!"@O%$gS>=@4U4bh$Fg`f5Eg`e'JD@tPs\W-N"equ.O5]lmecNIn^iE`^J#ZCjo*eP4^nqRu7Tg0",FpbABT3//V<D<cOTKD@uNsRUH7!_pM&$5IsC]Sei>JS<%>JPoD/Kids[\<`FqS4DQ&mIVF0HTp:fE0L5C.h]k+n?JYJ<<()J-cB`5djU-&+;R4O"K>M(SY]M-*50!klTW%V.>E7+TH#a<il>+q)1gd.\NBjbS;Zn4S67rL_BqoU]VV=.oQC-[3AjA5]d7ko+@\A,16Y!KV]M0&(Oh$aLf_A-3S,sfhSf3rFaZLYR(?X*?JPn6CgQ@Mcjog2aiKS+HKq=)#7YLQr(!jA37b2qp29"@2f9B4$5U8TN#,\H<4qe@9/<-A(UiPrn%9!'Pmg':9dguZYE4eLk+\mCammMO=mbS^1:;S$cli1!_31A![\Ut!SL5QQ2Yi?9t5q.kaqLOL6i$Z!GS/t![*P4$Q/\L$^abp"_9^6Q30dck)HAe[XdeEIlX0$><od8Q82#3j=tHO,CaM1'+20uCmWd$^l"(ijU7.jNCIq>#rcu-m=JNYK`jX]JemkGAeskY+:G,k8SeM\`X'%p!SMJm=GoI,Y^ggMW?p=:"4SK%!?Z5f!=o79J82PX^%%^3&GF?KZ8o-V_KN+ah,sPTqeG"t>OCbCW]d:1i_G&Q2kA82gVmnfI5"rVI*Bf#hI`8EiVR3c-(&ZG!KbQ_5,R*fHd+Rg>A^s"M`nPQZfUm^n$r&RQ*<(IIedYr<J1_epuR1k093=<^JXrXKC\mheb>DlqM4n<D.bp/F;.9jI^gb%4I3`]\'5/$m2eAe%@Lf?Z;6gcKP]+k@Ta),V@.*<$^mk"Ks`aRdtL1A%GPtJ?;H3?C"Ods<'n%X6;]<DgN4T=9>`Yn8Cl4n9c"GM1i0K(f`s?56FQ,FE@hXSF<Op___tdKXJK?p/gP4HfVT&HH5aFi,H57:PY"9N*2:T+e;(&e><TA<ZV^#rRSD*c9%)LI;f(5Hb.-]rF(MUrf-o[Qgc=Nnnp_o8UR@b#2XVJp>`8+Ie?j5IW1F;R^aoHFqT,/OSQars*:!2>:0<rL-Kb+VcAPLCb"u$=O@?:M4fmf2l1$*)ZdgY>SLtsWM7C`pg#`BPY"Zhf(=c)n0&4%J[n7M`TfFQD(aM/)n_OsLe%<h7B2Y[7`FDF<!U]/!q#~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 575
+>>
+stream
+GatU09lJc?%)(h*nCSJ[,3mppFm]#[A3dX!dUVPkD6c.?gpHtUUMRnM1:KF]Jo-TsHB4jN+`LW;]ZUZ?9**L7";FZ`!>SO0bi!7kq*PN7edBdX16J?-4VZgKTRN9TDX7XcU2%ep6RDlban]PV?'U<W>ef'D#%GY]k#\C/hYI!]'Pf*lKAI,B]qSJ\jbB68khb,ECGM)jZa7h6Fc8\bP]IqnR4[jck(5)+^RHI=<670t6,RFN1mmEm)hd6)Bl45Q*Cm#pciPtE:jZ<9&li$GU"'uHRP=qjha,3&E.+if<mhN]PV7/)(7[do@Eo]hDZUJk-Co;lE,r59q4r4%m5L\KK0=_Vj_nK.-6%]H,CDZs`cW^u*60KE;aGnA(iM\'"+;nu+5sEbLjm:)31'+!gBMlqZ?pu!=3pltLjf`8f%#S*M\A'=4I-N,qi.1ir$+G0-8[:CG<^UX2a1bg@(m_phG;/J:BT2Fa_:X=a)j=14+kPf%3s"Rb7O*#0&.G2Si-'0`6Ah*4CR[Ys)E_0HZ8b*BN'C($KgQ4!\G99,jaI6E4^Aa+Q7#@12/43rW*ee.7F~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000618 00000 n 
+0000000822 00000 n 
+0000000890 00000 n 
+0000001173 00000 n 
+0000001244 00000 n 
+0000003542 00000 n 
+0000005788 00000 n 
+trailer
+<<
+/ID 
+[<49edf9aa93d5ace7c038763b7ec5ffb4><49edf9aa93d5ace7c038763b7ec5ffb4>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 12
+>>
+startxref
+6454
+%%EOF

--- a/tests/pdfs/20191121 YY476-7-n-AG.pdf
+++ b/tests/pdfs/20191121 YY476-7-n-AG.pdf
@@ -1,0 +1,106 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20191121172856+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20191121172856+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 3 /Kids [ 3 0 R 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2156
+>>
+stream
+GauaC968iG'SZ;\("dUTbsX)_K!4P=:?odXg>$5\89Cql7(JK9p?*7="!g")G]?()d3Ke.P3:cn&\97'#fcO-D#PI$)*>sn*uBM8amsd*<1m@mKq7BsJ*W0J*LfS877eUX&aFFZJ8YM4+%Q0D@0O'WHn32q@a[f\4.T*Hl+!+c:J]k4Z@n4if:j0JPcJr;r12q6=oR:QrM;`dA#SB0Mg>4.^>HZ(,T\8,C34jVknBs=:b#1h_<4J]SUE^!a@,_ZH03Rt9!j?fJP;g5ON/cW-F#9s2]eT(Z`!W+.bOFU*R!nlO`5JB<99(<O=bQS'&M;0A'A`KB-EOP2Y>bKZFjNqkJ_aQ:2Yr#iRJHO`O]T\@fA@95K[a>O\%12Ol.H%Z`ZO;PEt=?SGlG^RO:.uE\!_lm;:!t0]>-*8Rg[VAe#)g%qMqQc[Y5G<Ve8cV'[>oKZ[a^$?_8"G5qOi87eM>IIsk<]<fAMH'V!FBBa;BoeDSD4/Pe6N;Jn5Y5r4[H^/0rg9)K.)7R'(<E?6hl;O"N/Tm=ICV+nW7Fj\T,!e[p7/\>Y6=^4QllSO0OV(8egI:$+@l+k1U9uA;Zd87-B(HICB5r>O7b_(rauV>ER7k"f<n`qG0$C9M:GD7;Vg7G>Wd)<JUb)eT.HY3>:E&W_Xr\\8Aofn;4I5-Q@'.1I4"Z+`6(0+54k=A1CLoXeX/B+05q'),3<"NGj'p\YTQDjW8E0j_7c*@!GH5kkITgkT73W+a_DA,>Vi1@UIg^G#lQ1qH6`E>XQVAC(+sKhjkT4*mK"r\*I/`#t>-W$gT]S+rJH#4nrDP8F7C?`kEa=]JmQuF;0`!X)n\E/&l@(cCX)[l6>Q]kB07cSX2V7bJ\[urbXO-S)Zs&gHUms-0nX2XF/B8:fnS.g/=I#rF&@Q$0mB6fF!j]jRXpEAU_HU]m87i!<!IYA[^rRU$^k;b@+?M!Y;@M3Z)HoE"jS&A#5V8YATiU@[M?#4NO$O-jq*R7-kgn)^Z@bKe%mH%fDcTQ)(=53-]fr3%#_;OW>=s>EW+4<Y7fLm]_b6X<O<'KfR7?'4@J?!tWC:n<[BcE.7%-k&U(1%Y(jT&<Qk62bA-\qhp<TbVmd.0T(=4qgL'25lBb+qZFc9M>aIcYOKL.754".KD\/4I;/#]ENF>^JhKF@mDhG>^mU0G@O(6HS@"cWAa"\^>s!j[Gf)Zoj3o@:6,C]WA@Z`EMl'/d1JnrDGlHIpLFl56mYO[$4okRsNlA-[h^nEOt>ZRC)NTW=d"QH',E!UX0Md%,^:fE1=T[XaK)[`J4VYQ\Qm`)^D6^>;$J(0a3$r:8jU+'M3\$`t[:qEj6dC(V\/C8'VRV\YC8PhO&?Z'H)=!T!A%P7tf#"A!io/KmVLj=tHO,CaM1'+20um%E!#re\$.X>;!1(OEB`?jfNon&Hi_/Kg*_$Q/\L$^abp"_7kW<r&ZEZC@s7><peJ96g5c8Gcd&aCEj(7fM$A-5:7sfg2m.ri($2G`71:I_%\V,>\arn#.NpZ:37tBTWeqL))J:5RYXC$7uJqG/F4r7/)QC/YMG2/YJ+i$Q/\,Mi97h>!R7%BN*i,N3ElpOSsKspCdqumXRH^N*B`lFU2*ba.$/GK7GJF3[CiC#0?ski0IDSF6Wp;7I77]8.KP1qB3'SG!iUs+/GKM$2Nt(D7"_NIC:f8c1\8`f`F+$KS<]BY::tm5W@AZEeINK@J^r^CgUe(m2I_BqVMQ._Xdk?PA5Pn7G3BFn#iLgkPD7:b_gE9YaA,p]bObTLV8Lm@k#Y%^7)>?p9lcW[l`\W)ukKaHki4cQ>YXd"dB_p[C4Js_K>VuZg!s0qPX>iF(]fGGne>UrO[><P-]H4IO&P^G%Y/ID?NY\L*G`4FO>i[fEpf:%>iR@l(SW,V\5l:&"30G)^/.eU"H?!.GBl(WaUcC,b8\;U(%F,)Q("TR?r1<+]GbA`2SJ?g/-j0_\?r9FK/c,2C+i.R%b%0[i2o^7dAJIXXi??<cb@tTk`*%XkLL$U"W46VL#\DC`VlcnKr,]F^2Cq4$T+B/_';e=pX;6ToPV/ni'XHM;(?;O$pLk^eEN!<25M=gO7>.3JTPBe$pT*c7g'"F4kSTg$XcTPX-4&k+XP#UK#ro/Eac)\1)lkqV]=UCOWn#U]1?1*qjL~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2109
+>>
+stream
+GauaC?ZXp\'ZJu$.J1.))8)+`=`tiI"!h`hq6Q;>S`q@B-D?Wb/gT3MpaZq-UFZmVVbT!@gJKVoF)Cl'\[%1uj7Xd"Io#JLl]'O=T*,gjNM]CJ7'Y,g3umYdD-pcN?6blh-BX!Qm:U6cY6'XJ4o8sP"g,`!P8IY`8LO18s)p;m9ua[/kj`\c):i5/j8%c5>X"C1hq@3T)gu[S?gOh:9N@Am):*cJpY.W<ZB"1n45J5B5$9KNV=OO#Hqq_Km.at\M;l`Ao@\4@7?SS7F!cQ8UsYTO8oeX1(@:k3ep2-tV1c,lVMS,<`]>;VMipe!=@r6j^F-F_/aqAdS=4i7ElJ]&-$Ll_XkU6VR;^p05[!5R[qgc)1g@FG<7Y9_CR9(QHNp<3Al'2RB2I[1%#Slq$jq^4TTHcu:iKqLMqo%[OSR@Y!t^p7XW+fRG+R<R<Cumqb9$Ar9;P6^V93URWiWH6.\:UQNJ:sKUVl[mj]o"4*hn&Wn,7V_3^ogT`A#CAKC+]&j+Un>O3M#AW@XWQ#Z2\gaotG+gH"VmnR=DJ5;_hX]9g%9F<F&I;-&T!iJ&.Nrq7;BZs54*D]b9]C]U*O+3OCZH,ZZT$Pt53MocG*n[S@6^FY^Co62`YEtRf3EWW@nm]b<U_eN9SiAI_-Gn[EA<^?Z^^;>\3Pn3!;TtDS"$Q'o/Y&DtRIQj<.Q1IR=J/0i45RYZA$>oKG1UnIZk3]1B"a#NT,6G6&E!:+M_,`o2aCEQu7e+h,-5:+ofiFeH3Z_HrJ/6KPrcLLU[=Ih:>*T`!"lqCQ!MamS!>>gJJ8D:98eY"&,#A[2?AqV^"^=5QU7DJ;0kp`aG\R6m$FPD#X46_8Xub)9C'!/<7@sW5TY,k7m79jO"lqCQ!MamS!>>gJaR$?+XXo"1(u`[>U2-`FmQE\?M"6F,fhp#bSm"N'U)#J@VA:m0:^bNcS(*o%^09\&C'!/YnG#7j$/>U9&aM/>*oe"iMWYa/Tl:C\[`Y_4n#R7t7mM1.UGDtYJFL/&AqUp#OiO*uN8gN79IS6hZE6H_`])JKGu[d1$g@;q_ZN5<Mb($em0fu.)I#HJ_\Oq``tgA&?jk&aMQM^'XC!r@<+?="p4iMu"^=6<?#;"u1.32$(,1Wd(,2Fi$coc6/WXhP(#e3iU?f%[XN1D+$JX^>A;r/`s)ktNXS]9u1.f_?TYA")/(eV2d')RU:)%)u%;6>UOiR4GMJrb#dHqC(#D>-r86<S>Q=>Y4<+cf<kW4Wh&?nT6>K&LYn#A8(-3Q`GIrHS;FV^+B]%Z:bL`0J_*lAaIMT6JdTjS8L[Yh2En#A8(2?ZFWIrop%WO@?L]%RKX=,Y.0fE+P4fE*B6C]W3iZ'Fib[3j[bJET%1.Ff2qY-;b,AQN@LaCEj(7e,+4-5:7sfiG?mn\)=WS3oP`5BY<LVZ^f:l'NduON4R/N8h)G9ISNpZ>F&T!%YA;qc#_dJF&qUg*>*N5e1?icliDS&@-g^1pMQ9!E_Up9jS:5'I0.=!b;OgJK.;!eQbAO,*m0P!DnQ-"am&$"[!(/!ig)MX+=7fiArS647"#%dG#*]+C0,rKI^M^3Wq"l'+HMN5l_ZsD>!<bi*mP^L)E7""`0fMGN.rf5jXJJ9mhj\'49uo@de^;2SQt)DG(+]+m+#4TNo-Xc&Md##;=oI`Kf30\T%G["ZDrR_NG<%D4&:B&^D'J/$A$<Kt=q2;0@;>iqb.4oj(,ee,K0W2B@8'9;H/arGs:Ql5u\2i@V\2O-A3%\Y0P%4:'W6%qRj/fqAp*)2.A'LLcL$)u:*Ve)5?emL]sK+ZK$:';XTA5,<ffgsCi)+:U:%+VCO/L/l;XIpjS_L-Ch,Bt0iIAO.5PkX-gj_[V#b#&1T@&+M=_?DgX'=VPuk-HO$Q.HhlV]eLPdCi%aZmZi'tf&b,Pi!2,Pra@3-mK[l>V"mqpEH+4Aj/H9FY4UiU3*'($FYp_?+4P9^d\d2r`Vj393,eo4nNVIAH..lh"J0d[=:OWe,'a(QQY3!9FV4R]'.0bP&NkU+r:03\>d4)SRuV-j[Qn)ao5_CfRd6-Eb;\e%KJ)&jppWk`jJfFAUe._1Bsslm(giUf4.F+Lff?M8+(8=k(]~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 576
+>>
+stream
+GatUp9iKe#&;KZL'mlb#=OHEgh"YQ6%a4qCKqg@48K*A`$16X=b#W=)2>Ft#CsVN5g/hI]KYV;0o.DMCZOE]q&5YVM#?4A_Fp$X.a_r(7==ZXPb=%5Nk"pReJbiqEZa!.o.B59DDitF!lKEW/ganA2%9N!o-X\*KgO)pNb-u4jItMP@fs0/@VpR"eAQW]Wq1A%pUTu5OaX0$]r(tEnA4elV"eD.\$*GpV!7P/!TG&hY#KggaD7g)%*)hK/pa+/onPjLMM?tjW5mMN=o4(DS7j,/W,GZ2%aSQ8U3lCW;V/8X)0gP'$MM)F/&Smai#1\J/@`kLq/c\BXq6l5s2cP5.8iH&3U+CbY2./7L83>b9feD#0+`JF!>YG>"Kjihgd!PUu6pKUZM@og&OZ8]"lJ%%TIGZY`lfD@H4JL`meZ'P8D`NAI`'\h-]g(aaKg5-I3MC&9^Uj]O](R:W%C9?pomSZ>IVQ+D:IaZZ4=lgtZnnZZgG#@<=6[Vnd=n'BdV"R;4EC$V09<D_^jeBBiS?Tngm>"T&-[,s7tHtb(*r8)c#B#aPT\q-%PfL`9`>&loI5I~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000618 00000 n 
+0000000822 00000 n 
+0000000890 00000 n 
+0000001173 00000 n 
+0000001244 00000 n 
+0000003491 00000 n 
+0000005692 00000 n 
+trailer
+<<
+/ID 
+[<16930aaa33ae33cdef5934ead2177ef4><16930aaa33ae33cdef5934ead2177ef4>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 12
+>>
+startxref
+6359
+%%EOF

--- a/tests/pdfs/20191121 YY479-9-n-AH.pdf
+++ b/tests/pdfs/20191121 YY479-9-n-AH.pdf
@@ -1,0 +1,106 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20191121172855+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20191121172855+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 3 /Kids [ 3 0 R 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2170
+>>
+stream
+GauaC?#uJp'Sc)J.s/*ZfhTda6@AGYhruK4A.rj,8SuncA)jZXFSFt%A7GWX0Lp%Q;GWcZ%_V6BHB8X[.N$bZZ2&T+BC%ThJ"@#p,YK5H:nD.\2*4GArm;fbDAu._"Hb&FiTko65jou"No"ikg&HB!`/PDeI$W[CiQ5n>9ZPhF>s<c8`"Ft;a4YLH@_]80jn/H1H;XUVdN:%=?sN`_T?>beTpLEpI,VfgDFpTq@%5O%f<6Yr7`hSG*F3jbKX($2MW8(5\^%poc_mD&8A<"qI-OIhp5m.T;%W0e(rb&O1a_b4j7@*\4J*B,]=GFal$Y$*c>Ks4T/#H6Kh`rRSR"(l]J=pJ;K6/5^YLO6LW+;*Xk3C02Hscga5JjZkA6F.T4[pi?E?@Ga[IrtHmD)1or#OQ1*>].TD>:sA#!,M`1s-A:Pn7)SB!1<9KYki#+e![8LW67T=SZhhFhjf8anm:P)tZNh;b"gHoUV))6#l>rShJ#QQOcP&okIK4tNeh-;\R6oI9ZG^U!hrTZh\bZA`#beY=\5et+db<GTAGP\"W+S'%J5?TlOUkoW2'+X8CerXfi.14hjdO.bFP#f`n3,\RHn1_U?fl]J-l4tih'c1dHn`V$bYChH`ugR,7i>e6K3inB?6OVdh2JiPBRkFGPMiZ8ne[MZe,S*->+EDXqd4[,mjk'jsfb0?9h3a]!N/VI#.S4(%\XOSNFb'Il)ca.Kk?RFNIquq_N`Nn5`l(c0!N>FDgC$jguY1D;&H.D-nLrA<c:S=k\/EV$P/_I2.O&-DT.g:NqCfHT5!J+-6pZO(A">0`:Zi:f[MYX#1R9*2dqDSfU1L!V\@a-7q3Zm\AK`EK.FK'%V2I7(.dn*l)]?fID:h4q[1]juIA%p+/;g6294hjaMF^@c4$.BW]$09c[r5bJ$QVWN>^@Lu+lR1!WMEia9HZX[)J//^Q67YM\+[?G!A'b9Hma)"^'PIO#6(sQQ^i!0!!j]jj8*:"i!Tacu65NH$BE<Ae>/83"g-J6<JejFg'O&6FIRJOl63=QFm`ESq.A]?2Ue>MQo`:_G;%"5O;i;&;JQb<^88;]U3;`U/;jO6qd5BFrIVKI/3jjc)6nMm/9J'^?TGEY1PhOKtWqO'*_hqV_f21cHW!/t;W!1[*C&oQ'C&ntT[=IV:e10B[XSZ-d74k15WBDJ*#`/,-=ud5OneJT`4GGFqjGkg"6GXG!*>D^"W7N6q[XdefkuIK6M2GJ%\YQYqmg<5`*J5+]EebDJ>lqB`m%D_nIlcBA/P9:Vk\=dLj:MDs5eAQZ\dOT,><j4H(,0dL()^H\[Xd_+fSTg1f=M:F@Z0HA?(BgF6OP>]Tp::8?\gg4/Rmd7/Mt-=e0;2N;B*._eri?OTR1j+Hq_&,!(iO0&o%P;*lAaIElSqLTjS8L%Z5,]?<Bk;Es>&,>YhdBC]WeVob_8K"lqCS!@)f)!>>gKJF&r].eh@pG-b1W$g8LF#rfU1BbtRdGmmoma;nL#KRtcu4".Pc]sRJ>[h02-bIaNr!k!Q!8M/ne/Y\7kM]<jPBE8bR[".M9cuPde-`iq+FK]B)!m2#"!pUW0J<;q#aQO80"_<CA2?p>(#R_4Efe6uP5I#`V$1+6mg_(!n6biaecFa3""C(uX+__)q8FF"i\$R?;;pPbG`:iMSB^\j&O!=C5(Gnea;<g`>:uB";6JJtOBDXa5Cu9T)/T@CTGd*+-<@&@dkTX5/NUUO1Cu8]QmH^jWIHLjHmMCJ4E;oo@Umg.G;-"juX(s01F5>AbBA#7o>g+PjP4Ca%<V1'f_VD>q.8Rh;G=H^uVn?g*4qO?ir"HrB>PLYgV1a8tA[HA0S\E6_qC\H?V>pNC:%'\E4;kAQ2m5_l2QttujD;j(m0h"CJ8*_6TGf!0ZlqYMKQP[t7,/(4V@E&b&uN2IRJ2DN+k*flY`XZSg5p'F@@B)")ek\:%>dOmVR[)&Q[*?ie$PgIObRT(:s_bN1i:<PUg]]M,TCHbV@E'-)SAZeDIa>\8Mg[Q5$#q%Wo_f*D3pZob%\tnB,f"U?sepQESIGO\rYVA_8L2cMYkgg33O6#gq8ld3@dhZ2QD!Er9Xf&ijPOqa%/&u?ThrniO.RmcA7cLbXp>ED7MZDGKiZN0D78EJa^QD/F>;qj1dF\c+`@ej2D,$J%Mt<rrIN2p`f~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2130
+>>
+stream
+GauaC?$"^Z'Sc)J.s/2Jm0m;mQMcl'cL?rSh5"1GR*P>e&<kI4TF5:SJ,W&jA]3SIoWFAddrs4CmsAk64ri7qJoUAplbCK$N-0mA[uZ+IabCHU<2A19P+<%Xr\Q:5I;^U'enHCN&Y%+6JGG:G3p)Weld&pUPdj`Qldt-V^$@jUB@HD7JXo$]S?eZm=D,!C/_MeYZ^BV*YNE/ug$f4c^:17Pc)^Dp<>+C":\NR:m/q'%$#C6#p\h]ro2a_:[G'fO5"R(FV6]H;pfrhsf]V*?'D[u2cY(iYc(d8[4C^_A8>\GQ:/N?:V$5WRf/V+#Vj(")_`/8Y:KU8#Cf.FYHR!63g\8W5FPo;PPiFS^Y+0H!=io^Ho&+[3;s"=oe5M[d_<j:X/CT5Ul7;1QgN?1M5!FTs+>YG:j"i)=A-PJCHj59kAl-S/1FP4<KDG$D9Tf/"KEDdS]n797>B]`+bdoL?Z=OOCr4,_%b>OVn<2ub&$n<<<Ti2EBp4m9^[E=ooQ9@Y3m%=)i.9_#!]"p)CneBh!haS!i\fX,dIgO5E1IHupE*=epbj<V`IuP5md;2gtqorI,g<bBfM-=%6nqa2+a7?tuQA+:<q=J(/Z:>,Gl"jADDMq^WR4iBL(bNc%m,ujWkBpD`U\aF](2"iD5NW)P!Sp&>IYUq-!lA/DAP/U1OM@6N(pVh)<K("u/HK+lkhNOWCcn=aVRON\>S*P39IS6hZAh2?4PL8cL:2QC.VJk=_:anM/Ke:b>CWkWciWbT[")"5["&Gd>!TMnBU''_<YD&/F9d;#;bAX7]VSZJ"DRs_N*="FS6E^]67j>7.((f>VcFD."a$r'(P75j+<AhS!pUW1J5J;6J-gp55djO)H$EC2CBCnomdRe\JJM'g6Q<K[V:G_=(q"lk3448CKj&#1)l-Ns^fl\9joEddeCO@8N`nhr9s&62H?i"4+qIP/(^3irQk63MB"(?He*t(Tn"5V)6nP(d*dmC42M#'t4((4+aCF!,7cE,(-5:=ufg`O&iLRA#oE^7jHh`9p/Kh\X[L&Wr5iaY5!MaUI!>>gIJ8D"-`o2obWaF:UciUeLp7Oq>C_>oKXaOfh=()KXA(UiPiRe2Y'Pmg'7^3]eSb4e:O=G&Ih9M\JVI0d&DlYI$6&*HjfE+P$fE*B6C]W3YZ/srH[3D.=6?FffPSG&Y?".$QPcV(mjM-ZiMR>[u?RDaS"k;-?Es5e:*r=Dl`/+OHZ2kC9/$eZ9=qT%&+M+,[k<>Tb,17dAKV]M0&(Oh$.(IPH-3S,sfg`5@_RjPW\-W2`mIi.8U!=k1AQN+9%8gOAaCEj(7cDu$-5:7sfg`5HiE`i<gkL@CG0eJe.+K)phH!iHk\:]T$sULq**^43Jh8,".(1nDX4DqC&J/6+/Z%/&dNu?pVsGmL!I5)X^aL1,^k@:k+PS<Q,.tD9KQ@ETm`5$$pQC%Y+<AlU!:gu8J5J;7J-cB`5dj7#F'qF;J"Na9(6Ipm00=hj$Rh@c&ip.\*C:P2#ppGW+92eJ2T]_A/B%mm]E$W6^FohTE&AHY/r:mE5lfCX@KE*/@K?u@Z%-SQ`+iZp7_"Hda:?oe/NUq'"f0=ZQ>f8$:ksQ)I"HnQ4:&_(Wf>l+#[@c_gb8iOY(>sQmS8/_+,IVYXbj6$BAs<t8F2>>hM)hKb&*!N0>oEF4j(auQg=tXFn!iHCL"DuR1$KB>@>?o,qQTWhhE"R(#_7U^>c0m>,]U0.ok2&.'>4$>Mk+`hp%c8>LUEdP=TH^[sP9rA+]qG4+(GfmVrk$+Zje>2"O%GkX#UM6>#FJ8pVX:F<TnF@>?JRrA8baL4."X:<3oN..u#m6Pn0W)Kt=2Z'U1c\rcF0Yer5,T>.TDZ9oGN]JT!%Kb?$J4*2Y-V.#-3,eZ&$d"T!%#-ZIr]e&_(M:B]lX]!MP#'soCr7T`-pYAL6=Dc6L9u.8gcJ6<6CtoK"\;7Ic?*SB.W8b);3j//;IlLIuF+#n"\/SCe/`P$+C#a*8HQ:Z<ht\A'NP+]#nH,2Nm8jC2]Ehh,qdhFFa#9ZaD8Kgd.D,o4>Wk7,'FQgkYfUST?jahX0e8QfXM-;)]55OUX7*p-MgMLh;&1ZL6QBYuPNfmtqP1[>A7nfm4Zg\ZrWSI7)pA~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 595
+>>
+stream
+GatU09lldh%))O>]Mlkq%-uI3Z7NQ*8_^W4bd96o*/TTgC@!Bhg:ptqCVVP/LQ2QU8PaY9TbTl!;"\/U^bimg,CpPl---@EA;1W:kSFVPCnqVsO\dcHNaW.t;3Qb[o.#2iB9HgQ=\5m8pia."D\hRIpFf=oL_4$`(<:(#_mJ'tf#P]-4d%C[X-3,p9?XAq'sX%tK)LqGVi8'7\tJTRUP[tQ%ed``rMr'3OYFecs59<A:\]<]%>l7_"](I6E\Je0'\\^;KT]e;\GS,FT(1T[E^m!(+WuOa_t&[`Q/WCL)+&!uKOF*b#X9E64Y%VTdguniQTO1;h!md53,?XK$6Y4[G+nMXnQgIb3kaip^P1&Mp3)uYIV&b^'@=eeiU_=ZXsq3I,Yb)'./jVQGRG7XnZ)\>&-'<[i:f2XQhjGUW5@B'*7osTo:5ari32,82BUk\EJc)2Qh9D3Ic4r*s2aq1,9@Wu3=TBQN"7F#bYMa#g0$GhH,*TF/%%O'^0Je:7cEm@h*eiWZ?/#tj/t",S$cam*O@l7b"hX7n5#)8nt'-9=m`e4/Lo_(7j6B6$W9jjB)%gt12%Ynd%.%CoG<>D.ld~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000618 00000 n 
+0000000822 00000 n 
+0000000890 00000 n 
+0000001173 00000 n 
+0000001244 00000 n 
+0000003505 00000 n 
+0000005727 00000 n 
+trailer
+<<
+/ID 
+[<0a74bcb33c43d2a44760fba46748b3ff><0a74bcb33c43d2a44760fba46748b3ff>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 12
+>>
+startxref
+6413
+%%EOF


### PR DESCRIPTION
Triggered by issue #4 

Added dump of data to log file for easier debugging on Windows machine
Added more explicit error for condition where status of gene in Excel report generated by SMP2v3 app in BaseSpace is not either 'Success' or 'Failure'.